### PR TITLE
Add agenda item to discuss language headings in prose (Dec comm call)

### DIFF
--- a/23-12-11/agenda.md
+++ b/23-12-11/agenda.md
@@ -21,6 +21,9 @@ Any questions from folks & anything to discuss
 - Content architechture workshop (new year)
 - Issues related to "Formal Syntax" section
   - Capturing updates to formal syntax (webRef updates not reflected in MDN prose)
-  - https://github.com/orgs/mdn/discussions/442
+  - Discussion thread: [What's the "current version" of a spec, for CSS reference docs?](https://github.com/orgs/mdn/discussions/442)
   - We are closing new mdn/content GitHub issues related to formal syntax because this is a bigger issue
   - Or should we hide the entire "Formal Syntax" section till we are able to provide correct and latest syntax info?
+- Would be nice to reach a consensus on this discussion: [Removal of redundant Markdown language headers](https://github.com/orgs/mdn/discussions/426)
+  - Pros/Cons for removing headings in prose
+  - Workarounds/solutions for still being able to refer to specific example prose if headings in prose are removed


### PR DESCRIPTION
- We need to reach some agreement about whether to retain or remove language headers in prose in "Examples" section.
This discussion should help to identify/highlight blockers for removing headers in prose. 

- For the previous agenda item, the link has been replaced with the title of discussion for better context