### PR TITLE
Add to agenda (Dec comm call): Opensource etiquette reminder

### DIFF
--- a/23-12-11/agenda.md
+++ b/23-12-11/agenda.md
@@ -2,6 +2,8 @@
 
 ## Intro & overview of agenda
 
+- Opensource etiquette reminder for everyone to [be respectful and kind with contributors as well as peers](https://developer.mozilla.org/en-US/docs/MDN/Community/Open_source_etiquette#be_polite_be_kind_avoid_incendiary_or_offensive_language)
+
 ## Team updates
 
 Any project updates from the MDN team


### PR DESCRIPTION
This can be moved to the appropriate place in the agenda or worded differently if required